### PR TITLE
chore: fix types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An interactive sticky item inspired by Facebook Stories.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index.ts",
   "files": [
     "src",


### PR DESCRIPTION
I got this error on VSCode and can't compile my project.

```
Could not find a declaration file for module '@gorhom/sticky-item'. 'node_modules/@gorhom/sticky-item/lib/commonjs/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/gorhom__sticky-item` if it exists or add a new declaration (.d.ts) file containing `declare module '@gorhom/sticky-item';` ts(7016)
```

This PR contains a simple fix for that.

Thanks!